### PR TITLE
Improve Config Handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - "**" # Triggers on push to any branch
+  pull_request:
+    branches:
+      - "**" # Triggers on pull requests targeting any branch
+  workflow_dispatch: # Allows manual triggering from the Actions tab
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the code
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Set up Go environment
+      - name: Set up Go (minimum version 1.20)
+        uses: actions/setup-go@v4
+        with:
+          go-version: ">=1.20"
+
+      # Cache dependencies
+      - name: Cache Go modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      # Install dependencies
+      - name: Install dependencies
+        run: go mod tidy
+
+      # Run tests
+      - name: Run tests
+        run: go test ./... -v

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,12 +22,22 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/chtc/chtc-go-logger/config"
 	"github.com/chtc/chtc-go-logger/logger"
 )
 
 func main() {
+	overrideConfig := config.Config{
+		FileOutput: config.FileOutputConfig{
+			FilePath: "/var/log/chtc-logger.log",
+		},
+	}
+
+	// Initialize the global logger and suppress error
+	_ = logger.LogInit(&overrideConfig)
+
 	// Example 1: Logging Without Context
-	nonContextLogger := logger.NewLogger()
+	nonContextLogger := logger.GetLogger()
 	nonContextLogger.Info("Hello, world!",
 		slog.String("status", "success"),
 		slog.String("module", "main"),
@@ -39,7 +49,7 @@ func main() {
 	)
 
 	// Example 2: Logging With Context
-	contextLogger := logger.NewContextAwareLogger()
+	contextLogger := logger.GetContextLogger()
 
 	// Create a context with attributes using the custom context key
 	ctx := context.WithValue(context.Background(), logger.LogAttrsKey, map[string]string{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestApplyOverrides(t *testing.T) {
+	// Define default config values
+	defaultConfig := &Config{
+		LogLevel: "INFO",
+		ConsoleOutput: ConsoleOutputConfig{
+			Enabled:    true,
+			JSONOutput: false,
+			Colors:     true,
+		},
+		FileOutput: FileOutputConfig{
+			Enabled:     true,
+			FilePath:    "/var/log/chtc/app.log",
+			MaxFileSize: 100,
+			MaxBackups:  5,
+			MaxAgeDays:  30,
+		},
+	}
+
+	// Define override values
+	overrides := &Config{
+		LogLevel: "DEBUG",
+		FileOutput: FileOutputConfig{
+			FilePath:    "/custom/path/logfile.log",
+			MaxFileSize: 200,
+		},
+	}
+
+	// Expected config after applying overrides
+	expectedConfig := &Config{
+		LogLevel: "DEBUG", // Overridden
+		ConsoleOutput: ConsoleOutputConfig{
+			Enabled:    true,  // Default retained
+			JSONOutput: false, // Default retained
+			Colors:     true,  // Default retained
+		},
+		FileOutput: FileOutputConfig{
+			Enabled:     true,                       // Default retained
+			FilePath:    "/custom/path/logfile.log", // Overridden
+			MaxFileSize: 200,                        // Overridden
+			MaxBackups:  5,                          // Default retained
+			MaxAgeDays:  30,                         // Default retained
+		},
+	}
+
+	// Apply overrides
+	ApplyOverrides(defaultConfig, overrides)
+
+	// Verify the results
+	if !reflect.DeepEqual(defaultConfig, expectedConfig) {
+		t.Errorf("ApplyOverrides failed.\nGot: %+v\nWant: %+v", defaultConfig, expectedConfig)
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,3 +1,20 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
 package config
 
 import (

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,69 @@
+package logger
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/chtc/chtc-go-logger/config"
+)
+
+// TestContextAwareLogger validates that the logger correctly extracts context attributes,
+// merges them with additional attributes, and logs them with the appropriate log level.
+func TestContextAwareLogger(t *testing.T) {
+	tempFile, err := os.CreateTemp("", "logfile-*.log")
+	if err != nil {
+		t.Fatalf("failed to create temporary log file: %v", err)
+	}
+	defer os.Remove(tempFile.Name()) // Clean up the temp file
+
+	// Create a configuration with the overridden file name
+	cfg := &config.Config{
+		FileOutput: config.FileOutputConfig{
+			Enabled:  true,
+			FilePath: tempFile.Name(), // Override file path
+		},
+	}
+
+	// Initialize the logger
+	contextLogger, err := NewContextAwareLogger(cfg)
+	if err != nil {
+		t.Fatalf("failed to initialize context-aware logger: %v", err)
+	}
+
+	ctx := context.WithValue(context.Background(), LogAttrsKey, map[string]string{
+		"user_id":    "12345",
+		"request_id": "abcde",
+	})
+
+	contextLogger.Info(ctx, "Test message", slog.String("extra_key", "extra_value"))
+
+	tempFile.Close()
+
+	// Read the log file and validate its contents
+	content, err := os.ReadFile(tempFile.Name())
+	if err != nil {
+		t.Fatalf("failed to read temporary log file: %v", err)
+	}
+
+	logContents := string(content)
+	expectedValues := []string{
+		`"user_id":"12345"`,
+		`"request_id":"abcde"`,
+		`"extra_key":"extra_value"`,
+		`"msg":"Test message"`,
+		`"level":"INFO"`,
+	}
+	for _, value := range expectedValues {
+		if !contains(logContents, value) {
+			t.Errorf("log does not contain expected value: %s", value)
+		}
+	}
+}
+
+// Helper function to check if a string is contained
+func contains(content, substring string) bool {
+	return len(content) >= len(substring) && strings.Contains(content, substring)
+}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,3 +1,20 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
 package logger
 
 import (


### PR DESCRIPTION
This PR improves the way we pass configuration to initialize new loggers. It follows the same model as used in Viper. With this PR, we maintain a global logger that can be configured using the `LogInit` function. However, there is also the flexibility of creating a new logger without modifying the global logger using the `NewLogger` function.

For most cases, applications would simply need to call `LogInit` and use the global logger variable for all logging. In cases where a change in behavior is required, the application can create a new logger altogether without affecting the global logger.

This PR also adds tests and introduces a GitHub workflow to run tests on push and pull requests for quick feedback.