### PR TITLE
Scratch: Return Log Results via ContextAwareLogger

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -28,6 +29,7 @@ import (
 
 	"github.com/chtc/chtc-go-logger/config"
 	"github.com/chtc/chtc-go-logger/logger"
+	"github.com/chtc/chtc-go-logger/logger/handlers"
 )
 
 func main() {
@@ -105,6 +107,11 @@ func runStreamMode() {
 	log.Info("All clients and server have exited.")
 }
 
+// TODO what do we do with logging stats besides log them??
+func printLogStats(stats handlers.LogStats) {
+	fmt.Printf("%+v\n", stats)
+}
+
 // **BURST MODE: Runs a few quick log examples**
 func runBurstMode() {
 	log := logger.GetLogger()
@@ -133,27 +140,32 @@ func runBurstMode() {
 		"requestID": "abc-123",
 	})
 
-	contextLogger.Info(ctx, "Operation completed",
+	stats := contextLogger.Info(ctx, "Operation completed",
 		slog.String("status", "success"),
 		slog.String("elapsedTime", "34ms"),
 		slog.String("result", "ok"),
 	)
-	contextLogger.Warn(ctx, "Potential issue detected",
+
+	printLogStats(stats)
+	stats = contextLogger.Warn(ctx, "Potential issue detected",
 		slog.String("code", "123"),
 		slog.String("severity", "high"),
 		slog.String("retryable", "false"),
 	)
-	contextLogger.Error(ctx, "Operation failed",
+	printLogStats(stats)
+
+	stats = contextLogger.Error(ctx, "Operation failed",
 		slog.String("error", "timeout"),
 		slog.String("endpoint", "/api/v1/data"),
 		slog.String("method", "POST"),
 	)
+	printLogStats(stats)
 }
 
 func init() {
 	overrideConfig := config.Config{
 		FileOutput: config.FileOutputConfig{
-			FilePath: "/var/log/chtc-logger.log",
+			FilePath: "/tmp/chtc-logger.log",
 		},
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,7 +20,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -29,7 +28,6 @@ import (
 
 	"github.com/chtc/chtc-go-logger/config"
 	"github.com/chtc/chtc-go-logger/logger"
-	"github.com/chtc/chtc-go-logger/logger/handlers"
 )
 
 func main() {
@@ -107,11 +105,6 @@ func runStreamMode() {
 	log.Info("All clients and server have exited.")
 }
 
-// TODO what do we do with logging stats besides log them??
-func printLogStats(stats handlers.LogStats) {
-	fmt.Printf("%+v\n", stats)
-}
-
 // **BURST MODE: Runs a few quick log examples**
 func runBurstMode() {
 	log := logger.GetLogger()
@@ -140,26 +133,23 @@ func runBurstMode() {
 		"requestID": "abc-123",
 	})
 
-	stats := contextLogger.Info(ctx, "Operation completed",
+	contextLogger.Info(ctx, "Operation completed",
 		slog.String("status", "success"),
 		slog.String("elapsedTime", "34ms"),
 		slog.String("result", "ok"),
 	)
 
-	printLogStats(stats)
-	stats = contextLogger.Warn(ctx, "Potential issue detected",
+	contextLogger.Warn(ctx, "Potential issue detected",
 		slog.String("code", "123"),
 		slog.String("severity", "high"),
 		slog.String("retryable", "false"),
 	)
-	printLogStats(stats)
 
-	stats = contextLogger.Error(ctx, "Operation failed",
+	contextLogger.Error(ctx, "Operation failed",
 		slog.String("error", "timeout"),
 		slog.String("endpoint", "/api/v1/data"),
 		slog.String("method", "POST"),
 	)
-	printLogStats(stats)
 }
 
 func init() {

--- a/logger/error_logger.go
+++ b/logger/error_logger.go
@@ -1,0 +1,40 @@
+package logger
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	handler "github.com/chtc/chtc-go-logger/logger/handlers"
+)
+
+// Wrapper for ContextAwareErrorLogger that returns the latest log info with each logger call
+type ContextAwareErrorLogger struct {
+	mu sync.Mutex
+	ContextAwareLogger
+}
+
+func (l *ContextAwareErrorLogger) Log(ctx context.Context, level slog.Level, msg string, attrs ...slog.Attr) handler.LogStats {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.ContextAwareLogger.Log(ctx, level, msg, attrs...)
+	return l.statHandler.GetLatestStats()
+}
+
+// Convenience methods for log levels
+func (l *ContextAwareErrorLogger) Info(ctx context.Context, msg string, attrs ...slog.Attr) handler.LogStats {
+	return l.Log(ctx, slog.LevelInfo, msg, attrs...)
+}
+
+func (l *ContextAwareErrorLogger) Debug(ctx context.Context, msg string, attrs ...slog.Attr) handler.LogStats {
+	return l.Log(ctx, slog.LevelDebug, msg, attrs...)
+}
+
+func (l *ContextAwareErrorLogger) Warn(ctx context.Context, msg string, attrs ...slog.Attr) handler.LogStats {
+	return l.Log(ctx, slog.LevelWarn, msg, attrs...)
+}
+
+func (l *ContextAwareErrorLogger) Error(ctx context.Context, msg string, attrs ...slog.Attr) handler.LogStats {
+	return l.Log(ctx, slog.LevelError, msg, attrs...)
+}

--- a/logger/handlers/log_stats_handler.go
+++ b/logger/handlers/log_stats_handler.go
@@ -94,6 +94,7 @@ func (s *LogStatsHandler) Handle(ctx context.Context, r slog.Record) error {
 	}
 
 	// If filesystem logging is enabled, check usage
+	// This is probably a pretty big performance bottleneck
 	if s.logConfig.FileOutput.Enabled {
 		usage, err := s.statLogFS()
 		stats.DiskAvail = usage
@@ -105,6 +106,7 @@ func (s *LogStatsHandler) Handle(ctx context.Context, r slog.Record) error {
 		}
 	}
 
+	// Measure duration of logging + log metadata acquisition
 	elapsed := time.Since(start)
 	stats.Duration = elapsed
 

--- a/logger/handlers/log_stats_handler.go
+++ b/logger/handlers/log_stats_handler.go
@@ -1,0 +1,123 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+package handlers
+
+import (
+	"context"
+	"log/slog"
+	"path"
+	"time"
+
+	"github.com/chtc/chtc-go-logger/config"
+	"golang.org/x/sys/unix"
+)
+
+type LogError struct {
+	Err    error
+	Record slog.Record
+}
+
+type LogStats struct {
+	Duration  time.Duration
+	DiskAvail uint64
+	Error     *LogError
+}
+
+// Handler that wraps another slog handler, forwarding its output to syslog
+type LogStatsHandler struct {
+	handler     slog.Handler
+	logConfig   config.Config
+	latestStats LogStats
+}
+
+func (s *LogStatsHandler) GetLatestStats() LogStats {
+	return s.latestStats
+}
+
+// NewLogStatsHandler constructs a new metrics-collecting log handler
+// LogStatsHandler wraps the handler given in the constructor, collecting
+// info such as log message duration and disk usage with each log message
+func NewLogStatsHandler(logConfig config.Config, baseHandler slog.Handler) slog.Handler {
+	handler := LogStatsHandler{
+		handler:   baseHandler,
+		logConfig: logConfig,
+	}
+
+	return &handler
+}
+
+func (s *LogStatsHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return s.handler.Enabled(ctx, level)
+}
+
+func (s *LogStatsHandler) statLogFS() (uint64, error) {
+	fs := path.Dir(s.logConfig.FileOutput.FilePath)
+
+	stat := unix.Statfs_t{}
+
+	if err := unix.Statfs(fs, &stat); err != nil {
+		return 0, err
+	}
+
+	// Via stackoverflow, available blocks * blocksize
+	return stat.Bavail * uint64(stat.Bsize), nil
+}
+
+// Required by slog.Handler interface: Processes a log via the writing handler, then
+// forward to syslog
+func (s *LogStatsHandler) Handle(ctx context.Context, r slog.Record) error {
+	stats := LogStats{}
+	start := time.Now()
+
+	// Call into the actual log handler, checking for errors on result
+	err := s.handler.Handle(ctx, r)
+	if err != nil {
+		stats.Error = &LogError{
+			Err:    err,
+			Record: r,
+		}
+	}
+
+	// If filesystem logging is enabled, check usage
+	if s.logConfig.FileOutput.Enabled {
+		usage, err := s.statLogFS()
+		stats.DiskAvail = usage
+		if err != nil {
+			stats.Error = &LogError{
+				Err:    err,
+				Record: r,
+			}
+		}
+	}
+
+	elapsed := time.Since(start)
+	stats.Duration = elapsed
+
+	s.latestStats = stats
+	return err
+}
+
+// Required by slog.Handler interface: Groups attributes under a namespace for the writing handler
+func (s *LogStatsHandler) WithGroup(name string) slog.Handler {
+	return &LogStatsHandler{handler: s.handler.WithGroup(name)}
+}
+
+// Required by slog.Handler interface: Adds attributes to the writing handler
+func (s *LogStatsHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &LogStatsHandler{handler: s.handler.WithAttrs(attrs)}
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -190,7 +190,7 @@ func NewContextAwareLogger(params ...interface{}) (*ContextAwareLogger, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &ContextAwareLogger{logger: newLogger, statHandler: log.Handler().(*handler.LogStatsHandler)}, err
+	return &ContextAwareLogger{logger: newLogger, statHandler: newLogger.Handler().(*handler.LogStatsHandler)}, err
 }
 
 // Log logs a message at the specified level with context attributes and additional attributes


### PR DESCRIPTION
- Add a new `LogStatsHandler` logger that gathers basic timing and disk usage stats for each log message that occurs
- Update `ContextAwareLogger`'s Debug/Info/Error methods to return the latest stats gathered by `LogStatsHandler`