### PR TITLE
Add configuration for including a sequence number with each log

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -47,12 +47,18 @@ type HealthCheckConfig struct {
 	ElasticsearchURL         string        `mapstructure:"elasticsearch_url"`
 }
 
+type SequenceConfig struct {
+	Enabled     bool   `mapstructure:"enabled"`       // Enable or disable sequence logging
+	IdKey       string `mapstructure:"logger_id_key"` // The key to log the logger's unique ID under
+	SequenceKey string `mapstructure:"sequence_key"`  // The key to log the logger's message sequence number under
+}
 type Config struct {
 	LogLevel      string              `mapstructure:"log_level"`      // Log level (e.g., DEBUG, INFO, WARN, ERROR)
 	ConsoleOutput ConsoleOutputConfig `mapstructure:"console_output"` // Console output settings
 	FileOutput    FileOutputConfig    `mapstructure:"file_output"`    // File output settings
 	SyslogOutput  SyslogOutputConfig  `mapstructure:"syslog_output"`  // Syslog output settings
 	HealthCheck   HealthCheckConfig   `mapstructure:"health_check"`   // Health Check Settings
+	SequenceInfo  SequenceConfig      `mapstructure:"sequence_info"`  // Include info about sequence of log message
 }
 
 // LoadConfig loads and merges the configuration in this order:

--- a/config/resources/default.yaml
+++ b/config/resources/default.yaml
@@ -45,3 +45,8 @@ health_check: # Health check settings
   elasticsearch_periodicity: "30s" # Interval for querying Elasticsearch
   elasticsearch_index: "healthcheck_logs" # Index name for storing health check logs
   elasticsearch_url: "http://your-elasticsearch-host:9200" # Added Elasticsearch URL
+
+sequence_info: # Configure recording sequencing of log info
+  enabled: true # Enable including log sequence information
+  logger_id_key: logger_id # Key to record each logger object's unique ID under
+  sequence_key: sequence # Key to record each log message's unique sequence under

--- a/config/resources/default.yaml
+++ b/config/resources/default.yaml
@@ -49,4 +49,4 @@ health_check: # Health check settings
 sequence_info: # Configure recording sequencing of log info
   enabled: true # Enable including log sequence information
   logger_id_key: logger_id # Key to record each logger object's unique ID under
-  sequence_key: sequence # Key to record each log message's unique sequence under
+  sequence_key: sequence_no # Key to record each log message's unique sequence under

--- a/logger/log_stats.go
+++ b/logger/log_stats.go
@@ -135,8 +135,9 @@ func (s *logDispatchStatHandler) Handle(ctx context.Context, r slog.Record) erro
 
 	// Set the sequence number on the log
 	if s.logConfig.SequenceInfo.Enabled {
-		r.Add(slog.String(s.logConfig.SequenceInfo.IdKey, s.logId))
-		r.Add(slog.Int64(s.logConfig.SequenceInfo.SequenceKey, int64(s.sequence.Add(1))))
+		r.Add(slog.Group("sequence_info",
+			slog.String(s.logConfig.SequenceInfo.IdKey, s.logId),
+			slog.Int64(s.logConfig.SequenceInfo.SequenceKey, int64(s.sequence.Add(1)))))
 	}
 	// Call into the actual log handler, checking for errors on result
 	errs := make([]LogError, 0, len(s.handlers))

--- a/logger/log_stats_test.go
+++ b/logger/log_stats_test.go
@@ -20,9 +20,12 @@ package logger
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"path"
+	"regexp"
+	"sync"
 	"testing"
 	"time"
 
@@ -362,4 +365,55 @@ func TestLogStatsElapsed(t *testing.T) {
 	if delay > 2*expectedDelay {
 		t.Fatalf("Expected log duration of less than %v, got %v", 2*expectedDelay, delay)
 	}
+}
+
+// Create a large number of logs in parallel, then
+// verify that every sequence number appears in the
+// resulting output
+func TestLogSequencing(t *testing.T) {
+	testDir := t.TempDir()
+
+	messageCount := 500
+
+	cfg := config.Config{
+		FileOutput: config.FileOutputConfig{
+			FilePath: path.Join(testDir, "out.log"),
+			Enabled:  true,
+		},
+		SequenceInfo: config.SequenceConfig{
+			Enabled: true,
+		},
+	}
+
+	log, err := NewContextAwareLogger(cfg)
+
+	if err != nil {
+		t.Fatalf("Unable to create logger: %v", err)
+	}
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < messageCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			log.Info(context.Background(), "Test msg")
+		}()
+	}
+	wg.Wait()
+
+	// Confirm that every sequence number is included exactly once
+	file_contents, err := os.ReadFile(cfg.FileOutput.FilePath)
+	if err != nil {
+		t.Fatalf("Unable to read logger output: %v", err)
+	}
+	file_str := string(file_contents)
+
+	for i := 1; i <= messageCount; i++ {
+		match, err := regexp.MatchString(fmt.Sprintf("\"sequence\":%v", i), file_str)
+		if err != nil || !match {
+			t.Fatalf("Sequence #%v not found in output!", i)
+		}
+	}
+
 }

--- a/logger/log_stats_test.go
+++ b/logger/log_stats_test.go
@@ -410,7 +410,7 @@ func TestLogSequencing(t *testing.T) {
 	file_str := string(file_contents)
 
 	for i := 1; i <= messageCount; i++ {
-		match, err := regexp.MatchString(fmt.Sprintf("\"sequence\":%v", i), file_str)
+		match, err := regexp.MatchString(fmt.Sprintf("\"sequence_no\":%v", i), file_str)
 		if err != nil || !match {
 			t.Fatalf("Sequence #%v not found in output!", i)
 		}


### PR DESCRIPTION
- Add an atomic.Uint64 shared among a logger and all its child loggers
- Atomically increment this int and record its new value in each outgoing log message
- Add config parameters to enable/disable this behavior